### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    return unless item.user_id == current_user.id
+
+    item.destroy
+    redirect_to root_path
+  end
+
   private
 
   def move_to_sign_in

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? && current_user.id != @item.user_id %>
 
       <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
`items#destroy`アクションを定義し、商品削除後はトップページへリダイレクトするよう実装をした

# Why
商品削除機能を実装するため

# Gyazo
[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/e055e2e326149a986d02207c0ff8f0c7)